### PR TITLE
Updating policy of lambda function to allow DescribeContainerInstances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ data "aws_region" "current" {}
 module "example_module_test" {
   source = "git::https://github.com/edispark/terraform-ecs-container-instance-draining"
 
-  autoscaling_group_name = "arn:partition:service:region:account-id:autoScalingGroupName/XXX"
-  autoscaling_group_arn = "my-asg-name"
+  autoscaling_group_arn = "arn:partition:service:region:account-id:autoScalingGroupName/XXX"
+  autoscaling_group_name = "my-asg-name"
   ecs_cluster_arn = "arn:partition:service:region:account-id:cluster/XXX"
   ecs_cluster_name = "my-ecs-cluster-name"
 

--- a/iam.tf
+++ b/iam.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "lambda" {
     resources = [
       var.ecs_cluster_arn,
       format("%s/*", var.ecs_cluster_arn),
-      format("arn:aws:ecs:%s:%s:container-instance/%s/*", var.region, data.aws_caller_identity.current.account_id, var.ecs_cluster_name)
+      format("arn:aws:ecs:%s:%s:container-instance/*", var.region, data.aws_caller_identity.current.account_id)
     ]
   }
 


### PR DESCRIPTION
Arn format of container instance do not have cluster name, so thats why lambda function provide this feedback:

[ERROR] AccessDeniedException: An error occurred (AccessDeniedException) when calling the DescribeContainerInstances operation: User: arn:aws:sts::user:assumed-role/test-draining-function-role/test-draining-function is not authorized to perform: ecs:DescribeContainerInstances on resource: arn:aws:ecs:eu-north-1:test:container-instance/instance_id
Traceback (most recent call last):
  File "/var/task/index.py", line 47, in lambda_handler
    if instance_has_running_tasks(msg['EC2InstanceId']):
  File "/var/task/index.py", line 29, in instance_has_running_tasks
    (instance_arn, container_status, running_tasks) = find_ecs_instance_info(instance_id)
  File "/var/task/index.py", line 18, in find_ecs_instance_info
    containerInstances=arns)
  File "/var/runtime/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 635, in _make_api_call
    raise error_class(parsed_response, operation_name)