### PR TITLE
feat: upgrade terraform aws provider

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-          env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec && go get github.com/segmentio/terraform-docs@v0.9.1
+          curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           pre-commit install
           pre-commit install-hooks
       - name: Run pre-commit tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/tags/v0.9.1 | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           pre-commit install
           pre-commit install-hooks
       - name: Run pre-commit tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,8 @@ jobs:
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-          env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec && go get github.com/segmentio/terraform-docs@v0.9.1
+          curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && sudo mv tfsec /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && sudo mv terraform-docs /usr/bin/
           pre-commit install
           pre-commit install-hooks
       - name: Run pre-commit tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && sudo mv tfsec /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           pre-commit install
           pre-commit install-hooks
       - name: Run pre-commit tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
           pip install pre-commit
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")" > tfsec && chmod +x tfsec && sudo mv tfsec /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/tags/v0.9.1 | grep -o -E "https://.+?-linux-amd64")" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           pre-commit install
           pre-commit install-hooks
       - name: Run pre-commit tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v3.3.0
     hooks:
       - id: check-merge-conflict
       - id: check-json
@@ -13,7 +13,7 @@ repos:
         args:
           - --allow-missing-credentials
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ module "example_module_test" {
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 | local | 1.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | >= 3.0 |
 | local | 1.4.0 |
 
 ## Inputs

--- a/iam.tf
+++ b/iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "lambda" {
     ]
 
     resources = [
-      aws_cloudwatch_log_group.lambda_log_group.arn
+      format("%s:*", aws_cloudwatch_log_group.lambda_log_group.arn)
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "draining_lambda" {
   }
 
   filename         = data.local_file.lambda_zip.filename
-  source_code_hash = data.local_file.lambda_zip.content_base64
+  source_code_hash = filebase64sha256(data.local_file.lambda_zip.filename)
 
   tags = var.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
- Terraform AWS provider requires v3 or above.
- Fix to hash of lambda source